### PR TITLE
Update GShader Shader and Preset version

### DIFF
--- a/src/lib/lib.rs
+++ b/src/lib/lib.rs
@@ -446,7 +446,7 @@ pub async fn install_presets(
         .map_err(|_| ReShaderError::ExtractZipFile)?;
 
     CopyBuilder::new(
-        directory.join("GShade-Presets-master"),
+        directory.join("./GShade-Presets-master/FFXIV"),
         directory.join("reshade-presets"),
     )
     .overwrite(true)
@@ -461,12 +461,12 @@ pub async fn install_presets(
         .map_err(|_| ReShaderError::ExtractZipFile)?;
 
     CopyBuilder::new(
-        directory.join("gshade-shaders"),
+        directory.join("./GShade-C-Shaders-main/gshade-shaders"),
         directory.join("reshade-shaders"),
     )
     .overwrite(true)
     .run()?;
-    std::fs::remove_dir_all(directory.join("gshade-shaders"))?;
+    std::fs::remove_dir_all(directory.join("GShade-C-Shaders-main"))?;
 
     let intermediate_path = directory.join("reshade-shaders").join("Intermediate");
     if !intermediate_path.exists() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -187,7 +187,8 @@ async fn tui(
                 if open {
                     tui::print_gshade_file_move(data_dir);
 
-                    let _ = open::that("https://github.com/HereInPlainSight/gshade_installer/blob/master/gshade_installer.sh#L352");
+                    let _ = open::that("https://gitlab.com/Mortalitas/GShade-C-Shaders/-/tree/main/gshade-shaders?ref_type=heads");
+                    let _ = open::that("https://gitlab.com/Mortalitas/GShade-Presets/-/tree/master/FFXIV?ref_type=heads");
                     tui::print_gshade_hint();
                 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -187,8 +187,8 @@ async fn tui(
                 if open {
                     tui::print_gshade_file_move(data_dir);
 
-                    let _ = open::that("https://gitlab.com/Mortalitas/GShade-C-Shaders/-/tree/main/gshade-shaders?ref_type=heads");
-                    let _ = open::that("https://gitlab.com/Mortalitas/GShade-Presets/-/tree/master/FFXIV?ref_type=heads");
+                    let _ = open::that("https://gitlab.com/Mortalitas/GShade-C-Shaders");
+                    let _ = open::that("https://gitlab.com/Mortalitas/GShade-Presets");
                     tui::print_gshade_hint();
                 }
 
@@ -199,8 +199,8 @@ async fn tui(
                 }
                 install_presets(
                     data_dir,
-                    &data_dir.join("presets.zip"),
-                    &data_dir.join("shaders.zip"),
+                    &data_dir.join("GShade-Presets-master.zip"),
+                    &data_dir.join("GShade-C-Shaders-main.zip"),
                 )
                 .await?;
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -133,10 +133,13 @@ pub fn print_gshade_hint() {
         "If your browser does not open, please open the following links manually:".cyan()
     );
     println!(
-        "{}",
-        "https://github.com/HereInPlainSight/gshade_installer/blob/master/gshade_installer.sh#L352"
+        "{}\n{}",
+        "https://gitlab.com/Mortalitas/GShade-C-Shaders/-/tree/main/gshade-shaders?ref_type=heads"
             .white()
-            .bold()
+            .bold(), 
+        "https://gitlab.com/Mortalitas/GShade-Presets/-/tree/master/FFXIV?ref_type=heads"
+            .white()
+            .bold(), 
     );
     println!();
 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -134,14 +134,16 @@ pub fn print_gshade_hint() {
     );
     println!(
         "{}\n{}",
-        "https://gitlab.com/Mortalitas/GShade-C-Shaders/-/tree/main/gshade-shaders?ref_type=heads"
+        "https://gitlab.com/Mortalitas/GShade-C-Shaders"
             .white()
             .bold(), 
-        "https://gitlab.com/Mortalitas/GShade-Presets/-/tree/master/FFXIV?ref_type=heads"
+        "https://gitlab.com/Mortalitas/GShade-Presets"
             .white()
             .bold(), 
     );
     println!();
+    println!(
+        "{}", "To download the required zip files, click the blue \"Code\" button and select \"zip\" under \"Download source code\"".cyan());
 }
 
 pub fn print_presets_success_no_games(directory: &Path) {


### PR DESCRIPTION
Commits fix the location of the GShade URL, as well as update the extraction process for the zip files once downloaded. Instructions were also added on how to get a "zip" file from the source. 